### PR TITLE
Remove leading zero on base-10 number.

### DIFF
--- a/os/migrating-to-clcs.md
+++ b/os/migrating-to-clcs.md
@@ -243,7 +243,7 @@ storage:
   files:
     - filesystem: "root"
       path:       "/etc/hostname"
-      mode:       0644
+      mode:       644
       contents:
         inline: coreos1
 ```
@@ -300,7 +300,7 @@ storage:
   files:
     - filesystem: "root"
       path:       "/etc/resolv.conf"
-      mode:       0644
+      mode:       644
       contents:
         inline: |
           nameserver 8.8.8.8
@@ -327,7 +327,7 @@ storage:
   files:
     - filesystem: "root"
       path:       "/etc/hosts"
-      mode:       0644
+      mode:       644
       contents:
         inline: |
           127.0.0.1	localhost


### PR DESCRIPTION
Per https://yaml.org/type/int.html a yaml variable may “…have leading “0” to signal an octal base…”

original from_files section is 644—using 0644 in the migrated YAML ends up leaving 420 after it's transpiled.